### PR TITLE
Rearrange parts in ruleset

### DIFF
--- a/source/generator.ts
+++ b/source/generator.ts
@@ -67,6 +67,10 @@ function selectRandomElementByWeight(rng: PseudoRandomNumberGenerator, input: (P
     throw new Error('input and weight lengths must match')
   }
 
+  if(input.length === 0) {
+    return null
+  }
+
   const aggregatedWeights = weights.map((sum => (value: number) => sum += value)(0))
   const weightTotal = rng() * weights.reduce((sum: number, weight) => sum + weight, 0)
   const index = aggregatedWeights.filter(el => weightTotal >= el).length

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -37,12 +37,7 @@ export async function generate(config: DocumentConfiguration, indexes?: IndexRul
   for (const part of config.parts) {
 
     const pseudoUniqueSvgId = Math.random().toString(36).substr(2, 5)
-    const svgData = fs.readFileSync(part.filePath)
-      .toString('utf8')
-      .replace(/<\?xml.*?\?>/, '')
-      .replace(/<!DOCTYPE.*?>/, '')
-      .replace(/width="100%" height="100%" viewBox="0 0 (\d+) (\d+)"/, 'width="$1" height="$2"')
-      .replace(/_clip(\d+)/g, `_clip$1_${pseudoUniqueSvgId}`)
+    const svgData = fs.readFileSync(part.filePath, { encoding: 'utf-8' }).replace(/_clip(\d+)/g, `_clip$1_${pseudoUniqueSvgId}`)
 
     const options: xml2js.ParserOptions = {
       strict: true,

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -19,7 +19,7 @@ export type DocumentConfiguration = {
 }
 
 /// generate svg data
-export async function generate(config: DocumentConfiguration, indexes?: IndexRule[]): Promise<string> {
+export async function generate(config: DocumentConfiguration, indexRules?: IndexRule[]): Promise<string> {
 
   const base: XmlTag = {
     '#name': 'svg',
@@ -75,8 +75,8 @@ export async function generate(config: DocumentConfiguration, indexes?: IndexRul
     }
   }
 
-  if (base.$$ && indexes) {
-    base.$$ = foo(base.$$, indexes)
+  if (base.$$ && indexRules) {
+    base.$$ = foo(base.$$, indexRules)
   }
 
   return xmlFromObject(base)

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -29,7 +29,14 @@ type DefinedXmlTag = XmlTag & {
   $$: XmlTag[]
 }
 
-type Attributes = { [name: string]: string }
+type Attributes = {
+  [name: string]: string
+}
+
+type PartIdentifier = {
+  partId: string
+  elementId: string | undefined
+}
 
 // global parser options for this file
 const options: xml2js.ParserOptions = Object.freeze({
@@ -53,7 +60,7 @@ export async function generate(config: DocumentConfiguration, indexRules?: Index
     $$: [],
   }
 
-  const namespaces: { [name: string]: string } = {} //todo: add all namespaces from all parts at the end
+  const namespaces: Attributes = {}
 
   for (const part of config.parts) {
     const data = await parsePartToXmlTag(part)
@@ -180,11 +187,6 @@ function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexRules: IndexRule[]): 
   }
 
   return mutableTags
-}
-
-type PartIdentifier = {
-  partId: string
-  elementId: string | undefined
 }
 
 function parsePartIdentifier(input: string): PartIdentifier | undefined {

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -137,7 +137,7 @@ function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexRules: IndexRule[]): 
 
     const a = parsePartIdentifier(indexRule[0])
     const b = parsePartIdentifier(indexRule[2])
-    const type = indexRule[1]
+    const type = indexRule[1] as string
 
     if (!a) {
       console.log(`a, invalid identifier: '${indexRule[0]}'. skipping ...`)
@@ -149,7 +149,7 @@ function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexRules: IndexRule[]): 
       continue
     }
 
-    if(type !== 'over' && type !== 'under') {
+    if (type !== 'over' && type !== 'under') {
       console.log(`invalid placement operator '${type}'. skipping ...`)
       continue
     }

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -114,7 +114,7 @@ function xmlFromObject(xml: XmlTag): string {
 </${tagName}>`
 }
 
-export function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexes: IndexRule[]): XmlTag[] {
+function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexes: IndexRule[]): XmlTag[] {
 
   let mutableTags = tags.slice() // copy array
 
@@ -135,39 +135,31 @@ export function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexes: IndexRule[
     }
 
     // fixme: ugly as h*ck to divide array like this
-
-    const shouldTagBeMoved = (child: XmlTag) => {
-      let shouldBeMoved = true
-
-      if (a.elementId) {
-        shouldBeMoved = child.$?.id === a.elementId
-      }
-
-      return shouldBeMoved && (child.$?.parent === a.partId)
-    }
-
+    const shouldTagBeMoved = (child: XmlTag) => (child.$?.parent === a.partId) && (a.elementId ? child.$?.id === a.elementId : true)
     const tagsToBeMoved = tags.filter(x => shouldTagBeMoved(x))
-    const tempRearranged = mutableTags.filter(x => !shouldTagBeMoved(x))
+    const tempRearrangedTags = mutableTags.filter(x => !shouldTagBeMoved(x))
 
-    const satisifiedElement = tempRearranged.find(x => {
+    // after temporarily removing some tags, check if there are is a part left which matches this conditions
+    const satisifiedSearchElement = tempRearrangedTags.find(x => {
       const childParentId = x.$?.parent
       const childElementId = x.$?.id
       return childParentId === b.partId && (b.elementId ? childElementId === b.elementId : true)
     })
 
-    if (satisifiedElement === undefined) {
+    if (satisifiedSearchElement === undefined) {
       console.log('cannot find part with element id')
       continue
     }
 
     // insert tags at specified element
-    tempRearranged.splice(
-      tempRearranged.indexOf(satisifiedElement) + (type === 'over' ? 1 : 0),
+    tempRearrangedTags.splice(
+      tempRearrangedTags.indexOf(satisifiedSearchElement) + (type === 'over' ? 1 : 0),
       0,
       ...tagsToBeMoved,
     )
     
-    mutableTags = tempRearranged
+    // update order of tags
+    mutableTags = tempRearrangedTags
   }
 
   return mutableTags

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -66,7 +66,7 @@ export async function generate(config: DocumentConfiguration, indexRules?: Index
     const data = await parsePartToXmlTag(part)
 
     if (!data) {
-      console.log(`invalid svg '${part.name}'. skipping ...`)
+      console.warn(`invalid svg '${part.name}'. skipping ...`)
       continue
     }
 
@@ -154,7 +154,7 @@ function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexRules: IndexRule[]): 
     }
 
     if (type !== 'over' && type !== 'under') {
-      console.log(`invalid placement operator '${type}'. skipping ...`)
+      console.error(`invalid placement operator '${type}'. skipping ...`)
       continue
     }
 

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -119,14 +119,38 @@ function xmlFromObject(xml: XmlTag): string {
 </${tagName}>`
 }
 
-function foo(arr: XmlTag[], indexes: IndexRule[]): XmlTag[] {
+export function foo(childElements: XmlTag[], indexes: IndexRule[]): XmlTag[] {
 
+  const returnArray = childElements.slice()
+
+  for (const indexRule of indexes) {
+
+    const reg = /^(\w+)(?:#(.+))?$/.exec(indexRule[0])
+
+    if (!reg?.[1]) {
+      console.log(`unparseable rule '${indexRule[0]}'`)
+      continue
+    }
+
+    const partId: string = reg[1]
+    const elementId: string | undefined = reg[2]
+    console.log(partId, elementId)
+
+    /*
+    for (const child of childElements) {
+
+      if ()
+    }
+    */
+  }
+
+  /*
   // fixme: implement index rules
-  const a = arr.slice()
   const removed = a.splice(5, 1)
   if (removed) {
     a.splice(a.length - 5, 0, ...removed)
   }
+  */
 
-  return a
+  return returnArray
 }

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -18,6 +18,14 @@ export type DocumentConfiguration = {
   parts: Part[]
 }
 
+// global parser options for this file
+const options: xml2js.ParserOptions = Object.freeze({
+  strict: true,
+  explicitArray: false,
+  explicitChildren: true,
+  preserveChildrenOrder: true,
+})
+
 /// generate svg data
 export async function generate(config: DocumentConfiguration, indexRules?: IndexRule[]): Promise<string> {
 
@@ -36,15 +44,9 @@ export async function generate(config: DocumentConfiguration, indexRules?: Index
 
   for (const part of config.parts) {
 
-    const pseudoUniqueSvgId = Math.random().toString(36).substr(2, 5)
-    const svgData = fs.readFileSync(part.filePath, { encoding: 'utf-8' }).replace(/_clip(\d+)/g, `_clip$1_${pseudoUniqueSvgId}`)
-
-    const options: xml2js.ParserOptions = {
-      strict: true,
-      explicitArray: false,
-      explicitChildren: true,
-      preserveChildrenOrder: true,
-    }
+    const pseudoUniqueId = Math.random().toString(36).substr(2, 5)
+    const svgData = fs.readFileSync(part.filePath, { encoding: 'utf-8' })
+      .replace(/_clip(\d+)/g, `_clip$1_${pseudoUniqueId}`)
 
     const partData = (await xml2js.parseStringPromise(svgData, options)).svg as XmlTag
     for (const element of partData.$$ ?? []) {

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -114,11 +114,11 @@ function xmlFromObject(xml: XmlTag): string {
 </${tagName}>`
 }
 
-function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexes: IndexRule[]): XmlTag[] {
+function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexRules: IndexRule[]): XmlTag[] {
 
   let mutableTags = tags.slice() // copy array
 
-  for (const indexRule of indexes) {
+  for (const indexRule of indexRules) {
 
     const a = parsePartIdentifier(indexRule[0])
     const b = parsePartIdentifier(indexRule[2])

--- a/source/svg-combiner.ts
+++ b/source/svg-combiner.ts
@@ -56,12 +56,7 @@ export async function generate(config: DocumentConfiguration, indexRules?: Index
   const namespaces: { [name: string]: string } = {} //todo: add all namespaces from all parts at the end
 
   for (const part of config.parts) {
-    const pseudoUniqueId = Math.random().toString(36).substr(2, 5)
-    const svgData = fs.readFileSync(part.filePath, { encoding: 'utf-8' })
-      .replace(/_clip(\d+)/g, `_clip$1_${pseudoUniqueId}`)
-
-    const parseData = await xml2js.parseStringPromise(svgData, options)
-    const data = parseData.svg as XmlTag | undefined
+    const data = await parsePartToXmlTag(part)
 
     if (!data) {
       console.log(`invalid svg '${part.name}'. skipping ...`)
@@ -118,6 +113,17 @@ function xmlFromObject(xml: XmlTag): string {
   return `<${tagName} ${attributesString}>
   ${children.map(child => xmlFromObject(child)).join('\n')}
 </${tagName}>`
+}
+
+async function parsePartToXmlTag(part: Part): Promise<XmlTag | undefined> {
+  const pseudoUniqueId = Math.random().toString(36).substr(2, 5)
+  const svgData = fs.readFileSync(part.filePath, { encoding: 'utf-8' })
+    .replace(/_clip(\d+)/g, `_clip$1_${pseudoUniqueId}`)
+
+  const parseData = await xml2js.parseStringPromise(svgData, options)
+  const data = parseData.svg as XmlTag | undefined
+
+  return data
 }
 
 function rearrangeXmlTagsByIndexRules(tags: XmlTag[], indexRules: IndexRule[]): XmlTag[] {


### PR DESCRIPTION
Change order of parts relative to other parts. This also includes moving elements of a part. Further explained in https://github.com/vladdeSV/me-generator/issues/4.

Syntax in the rulebook:

```jsonc
// rulebook.json
{
  // …
  "indexes": [
    ["A", "over", "B"]
    ["C#foo", "under", "D#bar"]
    ["E", "under", "F#baz"]
  ]
}
```

The identifiers follow the syntax
```
<part name> ( # <layer id> )
            |-- optional --|

example:
 'my part#second-layer'
 'my part'

invalid examples:
 'my part#second layer'
 'my part#'
```